### PR TITLE
Potential fix for code scanning alert no. 8: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/AIUB Forum API/Areas/HelpPage/Views/Web.config
+++ b/AIUB Forum API/Areas/HelpPage/Views/Web.config
@@ -25,7 +25,7 @@
   </appSettings>
 
   <system.web>
-    <compilation debug="true">
+    <compilation debug="false">
       <assemblies>
         <add assembly="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
       </assemblies>


### PR DESCRIPTION
Potential fix for [https://github.com/NafisianCastle/AIUB-Forum-with-Layer-Architecture/security/code-scanning/8](https://github.com/NafisianCastle/AIUB-Forum-with-Layer-Architecture/security/code-scanning/8)

To fix the problem, update the `<compilation>` element within the `<system.web>` section of the XML so that the `debug` attribute is set to `false` instead of `true`. This change ensures that ASP.NET will not include debug symbols or detailed error messages, which could expose sensitive implementation details to end users, and also improves performance. Only edit the `debug` attribute on line 28 in `AIUB Forum API/Areas/HelpPage/Views/Web.config`. No other functionality will be affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
